### PR TITLE
Typo fixes for sections 9.1 and 12.1

### DIFF
--- a/08-publication_bias.Rmd
+++ b/08-publication_bias.Rmd
@@ -92,7 +92,7 @@ An even better way to inspect the funnel plot is through **contour-enhanced funn
 ```{r,message=FALSE,warning=FALSE,eval=FALSE}
 funnel(m.hksj, xlab="Hedges' g", 
        contour = c(.95,.975,.99),
-       col.contour=c("darkblue","blue","lightblue"))+
+       col.contour=c("darkblue","blue","lightblue"))
 legend(1.4, 0, c("p < 0.05", "p<0.025", "< 0.01"),bty = "n",
        fill=c("darkblue","blue","lightblue"))
 ```

--- a/11-multilevel-meta-analysis.Rmd
+++ b/11-multilevel-meta-analysis.Rmd
@@ -213,7 +213,7 @@ model.l3.removed<-rma.mv(y,
                    sigma2 = c(0, NA))
 summary(model.l3.removed)
 
-anova(full.model, model.l2.removed)
+anova(full.model, model.l3.removed)
 
 ```
 


### PR DESCRIPTION
Fixed code for contour-enhanced funnel plot by removing '+' prior to legend(). Running the original code threw "non-numeric argument to binary operator" errors.

Using '+' is a ggplot2 idiom and won't work with base R plotting, although I imagine this error might also have creeped in from copying console output which retains the '+' characters from multi-line code blocks.